### PR TITLE
Added for non-network IPs in objects.filter()

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -19,7 +19,7 @@ class _NetAddressField(models.Field):
         if value is None:
             return value
 
-        return IP(value)
+        return IP(value , make_net=True)
 
     def get_prep_lookup(self, lookup_type, value):
         if value is None:


### PR DESCRIPTION
I noticed that I would get a value error from the IPy library if I were to do a filter query like the following:

    res = Obj.objects.filter(inet_field__net_contained='1.2.3.4/24')

But this _same_ query works if the ip address portion is the network address for the CIDR reference.  This works:

    res = Obj.objects.filter(inet_field__net_contained='1.2.3.0/24')

I just added the use of the `make_net=True` parameter to the `IPy.IP()` constructor, which will automatically convert the IP portion to the appropriate network address.