### PR TITLE
Django 1.7 fixes

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -28,7 +28,7 @@ class _NetAddressField(models.Field):
                 NET_OPERATORS[lookup_type] not in NET_TEXT_OPERATORS):
             if lookup_type.startswith('net_contained') and value is not None:
                 # Argument will be CIDR
-                return unicode(value)
+                return str(value)
             return self.get_prep_value(value)
 
         return super(_NetAddressField, self).get_prep_lookup(
@@ -38,7 +38,7 @@ class _NetAddressField(models.Field):
         if not value:
             return None
 
-        return unicode(self.to_python(value))
+        return str(self.to_python(value))
 
     def get_db_prep_lookup(self, lookup_type, value, connection,
             prepared=False):
@@ -109,7 +109,7 @@ class MACAddressField(models.Field):
         if not value:
             return None
 
-        return unicode(self.to_python(value))
+        return str(self.to_python(value))
 
     def formfield(self, **kwargs):
         defaults = {'form_class': MACAddressFormField}

--- a/netfields/forms.py
+++ b/netfields/forms.py
@@ -1,7 +1,6 @@
 from netaddr import IPAddress, IPNetwork, EUI, AddrFormatError
 
 from django import forms
-from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
 from django.core.exceptions import ValidationError
 
@@ -17,7 +16,7 @@ class NetInput(forms.Widget):
             value = ''
         final_attrs = self.build_attrs(attrs, type=self.input_type, name=name)
         if value:
-            final_attrs['value'] = force_unicode(value)
+            final_attrs['value'] = value
         return mark_safe(u'<input%s />' % forms.util.flatatt(final_attrs))
 
 
@@ -39,7 +38,7 @@ class InetAddressFormField(forms.Field):
 
         try:
             return IPAddress(value)
-        except (AddrFormatError, TypeError), e:
+        except (AddrFormatError, TypeError) as e:
             raise ValidationError(str(e))
 
 
@@ -61,7 +60,7 @@ class CidrAddressFormField(forms.Field):
 
         try:
             return IPNetwork(value)
-        except (AddrFormatError, TypeError), e:
+        except (AddrFormatError, TypeError) as e:
             raise ValidationError(str(e))
 
 

--- a/netfields/managers.py
+++ b/netfields/managers.py
@@ -159,6 +159,6 @@ class NetWhere(sql.where.WhereNode):
 class NetManager(models.Manager):
     use_for_related_fields = True
 
-    def get_query_set(self):
+    def get_queryset(self):
         q = NetQuery(self.model, NetWhere)
         return query.QuerySet(self.model, q)


### PR DESCRIPTION
This PR is to import work from @smclenithan.
Includes few fixes and remove warning appearing in Django1.7 on each single command : `netfields/managers.py:159: RemovedInDjango18Warning: 'NetManager.get_query_set' method should be renamed 'get_queryset'`