### PR TITLE
Add Django rest framework fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,19 @@
 language: python
-
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
+python: 2.7
 
 env:
-  - DJANGO='Django<=1.7'
-  - DJANGO='Django<=1.8'
-  - DRF='djangorestframework<=3.2.4'
+  - TOX_ENV=py27-django17
+  - TOX_ENV=py33-django17
+  - TOX_ENV=py34-django17
+  - TOX_ENV=py27-django18
+  - TOX_ENV=py33-django18
+  - TOX_ENV=py34-django18
 
 install:
-  - pip install -q psycopg2 --use-mirrors
-  - pip install -q $DJANGO --use-mirrors
-  - pip install -q netaddr --use-mirrors
-  - pip install -q $DRF --use-mirrors
-  - pip install -q unittest2 --use-mirrors
-  - pip install . --use-mirrors
+  - pip install tox --use-mirrors
 
 before_script:
   - psql -c 'create database netfields;' -U postgres
 
-script: "./manage.py test"
-
-matrix:
-  exclude:
-  - python: "2.6"
-    env: DJANGO='Django<=1.7'
-  - python: "2.6"
-    env: DJANGO='Django<=1.8'
+script:
+  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,14 @@ python:
 env:
   - DJANGO='Django<=1.7'
   - DJANGO='Django<=1.8'
+  - DRF='djangorestframework<=3.2.4'
 
 install:
   - pip install -q psycopg2 --use-mirrors
   - pip install -q $DJANGO --use-mirrors
   - pip install -q netaddr --use-mirrors
+  - pip install -q $DRF --use-mirrors
+  - pip install -q unittest2 --use-mirrors
   - pip install . --use-mirrors
 
 before_script:

--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -74,6 +74,7 @@ class _NetAddressField(models.Field):
 
 
 class InetAddressField(with_metaclass(models.SubfieldBase, _NetAddressField)):
+    short_name = "IP"
     description = "PostgreSQL INET field"
     max_length = 39
 
@@ -88,6 +89,7 @@ class InetAddressField(with_metaclass(models.SubfieldBase, _NetAddressField)):
 
 
 class CidrAddressField(with_metaclass(models.SubfieldBase, _NetAddressField)):
+    short_name = "CIDR"
     description = "PostgreSQL CIDR field"
     max_length = 43
 
@@ -108,6 +110,7 @@ class CidrAddressField(with_metaclass(models.SubfieldBase, _NetAddressField)):
 
 
 class MACAddressField(models.Field):
+    short_name = "MAC"
     description = "PostgreSQL MACADDR field"
 
     def db_type(self, connection):

--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -74,7 +74,6 @@ class _NetAddressField(models.Field):
 
 
 class InetAddressField(with_metaclass(models.SubfieldBase, _NetAddressField)):
-    short_name = "IP"
     description = "PostgreSQL INET field"
     max_length = 39
 
@@ -89,7 +88,6 @@ class InetAddressField(with_metaclass(models.SubfieldBase, _NetAddressField)):
 
 
 class CidrAddressField(with_metaclass(models.SubfieldBase, _NetAddressField)):
-    short_name = "CIDR"
     description = "PostgreSQL CIDR field"
     max_length = 43
 
@@ -110,7 +108,6 @@ class CidrAddressField(with_metaclass(models.SubfieldBase, _NetAddressField)):
 
 
 class MACAddressField(models.Field):
-    short_name = "MAC"
     description = "PostgreSQL MACADDR field"
 
     def db_type(self, connection):

--- a/netfields/rest_framework.py
+++ b/netfields/rest_framework.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from functools import partial
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers
+
+from netfields import fields
+
+
+def _validate_netaddr(netfields_type, value):
+    """Convert Django validation errors to DRF validation errors.
+    """
+    try:
+        field = netfields_type(value)
+        field.to_python(value)
+    except DjangoValidationError:
+        raise serializers.ValidationError("Invalid {} address.".format(field.short_name))
+
+
+class NetfieldsField(object):
+    def __init__(self, *args, **kwargs):
+        validators = kwargs.get('validators', [])
+        validators.append(partial(_validate_netaddr, self.netfields_type))
+        kwargs['validators'] = validators
+        super(NetfieldsField, self).__init__(*args, **kwargs)
+
+
+class InetAddressField(NetfieldsField, serializers.CharField):
+    netfields_type = fields.InetAddressField
+
+
+class CidrAddressField(NetfieldsField, serializers.CharField):
+    netfields_type = fields.CidrAddressField
+
+
+class MACAddressField(NetfieldsField, serializers.CharField):
+    netfields_type = fields.MACAddressField

--- a/test/test_rest_framework_fields.py
+++ b/test/test_rest_framework_fields.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+
+import unittest2 as unittest
+from netfields import rest_framework as fields
+
+
+class FieldsTestCase(unittest.TestCase):
+    def test_validation_inet_field(self):
+
+        class TestSerializer(serializers.Serializer):
+            ip = fields.InetAddressField()
+
+        serializer = TestSerializer(data={'ip': '10.0.0.'})
+        with self.assertRaises(serializers.ValidationError) as e:
+            serializer.is_valid(raise_exception=True)
+        self.assertEqual(e.exception.detail['ip'], ['Invalid IP address.'])
+
+    def test_validation_cidr_field(self):
+
+        class TestSerializer(serializers.Serializer):
+            cidr = fields.CidrAddressField()
+
+        serializer = TestSerializer(data={'cidr': '10.0.0.'})
+        with self.assertRaises(serializers.ValidationError) as e:
+            serializer.is_valid(raise_exception=True)
+        self.assertEqual(e.exception.detail['cidr'], ['Invalid CIDR address.'])
+
+    def test_validation_mac_field(self):
+
+        class TestSerializer(serializers.Serializer):
+            mac = fields.MACAddressField()
+
+        serializer = TestSerializer(data={'mac': 'de:'})
+        with self.assertRaises(serializers.ValidationError) as e:
+            serializer.is_valid(raise_exception=True)
+        self.assertEqual(e.exception.detail['mac'], ['Invalid MAC address.'])

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps=
     django==1.7
     netaddr
     psycopg2
-    djangorestframework==3.2.4
+    djangorestframework
     unittest2
 
 [testenv:py33-django17]
@@ -29,7 +29,7 @@ deps=
     django==1.7
     netaddr
     psycopg2
-    djangorestframework==3.2.4
+    djangorestframework
     unittest2
 
 [testenv:py34-django17]
@@ -38,7 +38,7 @@ deps=
     django==1.7
     netaddr
     psycopg2
-    djangorestframework==3.2.4
+    djangorestframework
     unittest2
 
 [testenv:py27-django18]
@@ -47,7 +47,7 @@ deps=
     django==1.8
     netaddr
     psycopg2
-    djangorestframework==3.2.4
+    djangorestframework
     unittest2
 
 [testenv:py33-django18]
@@ -56,7 +56,7 @@ deps=
     django==1.8
     netaddr
     psycopg2
-    djangorestframework==3.2.4
+    djangorestframework
     unittest2
 
 [testenv:py34-django18]
@@ -65,5 +65,5 @@ deps=
     django==1.8
     netaddr
     psycopg2
-    djangorestframework==3.2.4
+    djangorestframework
     unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ deps=
     django==1.7
     netaddr
     psycopg2
+    djangorestframework==3.2.4
+    unittest2
 
 [testenv:py33-django17]
 basepython=python3.3
@@ -27,6 +29,8 @@ deps=
     django==1.7
     netaddr
     psycopg2
+    djangorestframework==3.2.4
+    unittest2
 
 [testenv:py34-django17]
 basepython=python3.4
@@ -34,6 +38,8 @@ deps=
     django==1.7
     netaddr
     psycopg2
+    djangorestframework==3.2.4
+    unittest2
 
 [testenv:py27-django18]
 basepython=python2.7
@@ -41,6 +47,8 @@ deps=
     django==1.8
     netaddr
     psycopg2
+    djangorestframework==3.2.4
+    unittest2
 
 [testenv:py33-django18]
 basepython=python3.3
@@ -48,6 +56,8 @@ deps=
     django==1.8
     netaddr
     psycopg2
+    djangorestframework==3.2.4
+    unittest2
 
 [testenv:py34-django18]
 basepython=python3.4
@@ -55,3 +65,5 @@ deps=
     django==1.8
     netaddr
     psycopg2
+    djangorestframework==3.2.4
+    unittest2


### PR DESCRIPTION
This pull request adds IP, CIDR, and MAC address fields for DRF. These wrap the DRF `CharField` class, but add in a validator that catches the Django `ValidationError` and raise a new DRF `ValidationError`.