### PR TITLE
Fix case where validation is duplicated when using additional validators

### DIFF
--- a/netfields/rest_framework.py
+++ b/netfields/rest_framework.py
@@ -8,10 +8,8 @@ from netfields import fields
 
 class NetfieldsField(object):
     def __init__(self, *args, **kwargs):
-        validators = kwargs.get('validators', [])
-        validators.append(self._validate_netaddr)
-        kwargs['validators'] = validators
         super(NetfieldsField, self).__init__(*args, **kwargs)
+        self.validators.append(self._validate_netaddr)
 
     def _validate_netaddr(self, value):
         """Convert Django validation errors to DRF validation errors.

--- a/test/test_rest_framework_fields.py
+++ b/test/test_rest_framework_fields.py
@@ -36,3 +36,15 @@ class FieldsTestCase(unittest.TestCase):
         with self.assertRaises(serializers.ValidationError) as e:
             serializer.is_valid(raise_exception=True)
         self.assertEqual(e.exception.detail['mac'], ['Invalid MAC address.'])
+
+    def test_validation_additional_validators(self):
+        def validate(value):
+            raise serializers.ValidationError('Invalid.')
+
+        class TestSerializer(serializers.Serializer):
+            ip = fields.InetAddressField(validators=[validate])
+
+        serializer = TestSerializer(data={'ip': 'de:'})
+        with self.assertRaises(serializers.ValidationError) as e:
+            serializer.is_valid(raise_exception=True)
+        self.assertItemsEqual(e.exception.detail['ip'], ['Invalid IP address.', 'Invalid.'])


### PR DESCRIPTION
This fixes the case where you would receive duplicate validation messages when you were using multiple validators on a serializer field:

```
ip = InetAddressField(validators=[foo])
```

Would return the following errors when both the `foo` validator and internal validator failed:

```
[u'Foo error.', u'Invalid IP address.', u'Invalid IP address.']
```

