### PR TITLE
NetfieldsField inherit from serializers.CharField

### DIFF
--- a/netfields/rest_framework.py
+++ b/netfields/rest_framework.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 from netfields import fields
 
 
-class NetfieldsField(object):
+class NetfieldsField(serializers.CharField):
     def __init__(self, *args, **kwargs):
         super(NetfieldsField, self).__init__(*args, **kwargs)
         self.validators.append(self._validate_netaddr)
@@ -20,16 +20,16 @@ class NetfieldsField(object):
             raise serializers.ValidationError("Invalid {} address.".format(self.address_type))
 
 
-class InetAddressField(NetfieldsField, serializers.CharField):
+class InetAddressField(NetfieldsField):
     netfields_type = fields.InetAddressField
     address_type = "IP"
 
 
-class CidrAddressField(NetfieldsField, serializers.CharField):
+class CidrAddressField(NetfieldsField):
     netfields_type = fields.CidrAddressField
     address_type = "CIDR"
 
 
-class MACAddressField(NetfieldsField, serializers.CharField):
+class MACAddressField(NetfieldsField):
     netfields_type = fields.MACAddressField
     address_type = "MAC"


### PR DESCRIPTION
Otherwise we can't pass serializer fields parameters like source, default, etc.