### PR TITLE
New field subclassing format (Django 1.8+)

### DIFF
--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -109,8 +109,8 @@ class BaseInetTestCase(BaseSqlTestCase):
     def test_save_object(self):
         self.model(field=self.value1).save()
 
-    def test_init_with_text_fails(self):
-        self.assertRaises(ValidationError, self.model, field='abc')
+    def test_save_with_text_fails(self):
+        self.assertRaises(ValidationError, self.model.objects.create, field='abc')
 
     def test_iexact_lookup(self):
         self.assertSqlEquals(


### PR DESCRIPTION
This PR adds improved support for Django 1.8+ using the [new subclassing field format](https://docs.djangoproject.com/en/1.9/releases/1.8/#subfieldbase).
Old format is currently pending for deprecation, and will break after Django 1.10 release. This PR adds support for it, and remove associated deprecation warning.