### PR TITLE
Fix `'NoneType' object is not iterable` when using `__in` with empty list.

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -34,8 +34,6 @@ class _NetAddressField(models.Field):
             raise ValidationError(e)
 
     def get_prep_lookup(self, lookup_type, value):
-        if not value:
-            return None
 
         if (lookup_type in NET_OPERATORS and
                     NET_OPERATORS[lookup_type] not in NET_TEXT_OPERATORS):

--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -16,6 +16,7 @@ from ipaddress import (
 from netaddr import EUI
 
 from django.db import IntegrityError
+from django.db.models.sql import EmptyResultSet
 from django.core.exceptions import FieldError
 from django.test import TestCase
 from unittest import skipIf
@@ -89,6 +90,10 @@ class BaseSqlTestCase(object):
             self.qs.filter(field__in=[self.value1]),
             self.select + 'WHERE "table"."field" IN (%s)'
         )
+
+    def test_in_empty_lookup(self):
+        with self.assertRaises(EmptyResultSet):
+            self.qs.filter(field__in=[]).query.get_compiler(self.qs.db).as_sql()
 
     def test_gt_lookup(self):
         self.assertSqlEquals(


### PR DESCRIPTION
Problem case:
`model.objects.filter(<field>__in=[])` produces a `'NoneType' object is not iterable` exception.

Cause:
`get_prep_lookup` in `_NetAddressField` returns `None` if `value` is falsy.

Change:
Remove early return in `get_prep_lookup`. Superclass's `get_prep_lookup` will be called with the value instead.


Added unit test for `__in` empty list case.
An alternative (neater?) unit test would be simply performing a `self.qs.filter(field__in=[])` and checking it returns an empty query set.