### PR TITLE
Add a lookup for exact CIDR prefix length

### DIFF
--- a/netfields/apps.py
+++ b/netfields/apps.py
@@ -18,6 +18,7 @@ from netfields.lookups import (
     NetContains,
     NetContainsOrEquals,
     NetOverlaps,
+    Prefixlen,
     Regex,
     StartsWith,
 )
@@ -51,6 +52,7 @@ class NetfieldsConfig(AppConfig):
     CidrAddressField.register_lookup(Family)
     CidrAddressField.register_lookup(MaxPrefixlen)
     CidrAddressField.register_lookup(MinPrefixlen)
+    CidrAddressField.register_lookup(Prefixlen)
 
     InetAddressField.register_lookup(EndsWith)
     InetAddressField.register_lookup(IEndsWith)

--- a/netfields/lookups.py
+++ b/netfields/lookups.py
@@ -135,6 +135,15 @@ class Family(Transform):
 
 
 class _PrefixlenMixin(object):
+    format_string = None
+
+    def as_sql(self, qn, connection):
+        assert self.format_string is not None, "Prefixlen lookups must specify a format_string"
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return self.format_string % (lhs, rhs), params
+
     def process_lhs(self, qn, connection, lhs=None):
         lhs = lhs or self.lhs
         lhs_string, lhs_params = qn.compile(lhs)
@@ -147,19 +156,14 @@ class _PrefixlenMixin(object):
 
 class MaxPrefixlen(_PrefixlenMixin, Lookup):
     lookup_name = 'max_prefixlen'
-
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return '%s <= %s' % (lhs, rhs), params
+    format_string = '%s <= %s'
 
 
 class MinPrefixlen(_PrefixlenMixin, Lookup):
     lookup_name = 'min_prefixlen'
+    format_string = '%s >= %s'
 
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return '%s >= %s' % (lhs, rhs), params
+
+class Prefixlen(_PrefixlenMixin, Lookup):
+    lookup_name = 'prefixlen'
+    format_string = '%s = %s'

--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -299,6 +299,12 @@ class BaseCidrFieldTestCase(BaseInetTestCase):
             self.select + 'WHERE masklen("table"."field") >= %s'
         )
 
+    def test_prefixlen(self):
+        self.assertSqlEquals(
+            self.qs.filter(field__prefixlen='16'),
+            self.select + 'WHERE masklen("table"."field") = %s'
+        )
+
 
 class TestInetField(BaseInetFieldTestCase, TestCase):
     def setUp(self):


### PR DESCRIPTION
We have fallen into a pattern of, for example: `MyModel.objects.filter(network__max_prefixlen=24, network__min_prefixlen=24)`. To make this simpler, and allow for a single exact prefix length lookup, I've added `__prefixlen`. Also, as a side effect, I cleaned up the code a little bit for these lookups, making it more DRY.