### PR TITLE
Don't cast networks to str

### DIFF
--- a/netfields/managers.py
+++ b/netfields/managers.py
@@ -73,11 +73,3 @@ class NetManager(models.Manager):
     def get_queryset(self):
         q = NetQuery(self.model, NetWhere)
         return query.QuerySet(self.model, q)
-
-    def filter(self, *args, **kwargs):
-        for key, val in kwargs.items():
-            if isinstance(val, _BaseNetwork):
-                # Django will attempt to consume the _BaseNetwork iterator, which
-                # will convert it to a list of every address in the network
-                kwargs[key] = str(val)
-        return super(NetManager, self).filter(*args, **kwargs)

--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -227,6 +227,9 @@ class BaseInetFieldTestCase(BaseInetTestCase):
     def test_query_filter_ipaddress(self):
         self.model.objects.filter(field=ip_interface('1.2.3.4'))
 
+    def test_query_filter_contains_ipnetwork(self):
+        self.model.objects.filter(field__net_contains=ip_network('1.2.3.0/24'))
+
 
 class BaseCidrFieldTestCase(BaseInetTestCase):
     value1 = '10.0.0.1/32'


### PR DESCRIPTION
The explained problem doesn't happen, but it breaks usage with Python 2 port of "ipaddress" module [1].  This port doesn't accept "str".  This may not be a problem anymore because of the switch from "netaddr" to "ipaddress" [2].  Though, the network objects are still iterable.  Or maybe something got fixed on Django.  I don't know.  I tested on Django 1.8.1.

[1] https://pypi.python.org/pypi/ipaddress
[2] https://github.com/jimfunk/django-postgresql-netfields/commit/a5a1118
