### PR TITLE
Support array aggregation with netfields

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -19,6 +19,9 @@ class _NetAddressField(models.Field):
         super(_NetAddressField, self).__init__(*args, **kwargs)
 
     def from_db_value(self, value, expression, connection, context):
+        if isinstance(value, list):
+            # Aggregation detected, return a list of values
+            return [self.to_python(v) for v in value if v is not None]
         return self.to_python(value)
 
     def to_python(self, value):

--- a/test/models.py
+++ b/test/models.py
@@ -1,5 +1,5 @@
 from django.contrib.postgres.fields import ArrayField
-from django.db.models import Model
+from django.db.models import Model, ForeignKey
 
 from netfields import InetAddressField, CidrAddressField, MACAddressField, \
         NetManager
@@ -88,3 +88,13 @@ class MACArrayTestModel(Model):
 
     class Meta:
         db_table = 'macarray'
+
+
+class AggregateTestModel(Model):
+    pass
+
+
+class AggregateTestChildModel(Model):
+    parent = ForeignKey('AggregateTestModel', related_name='children')
+    network = CidrAddressField()
+    inet = InetAddressField()

--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -581,19 +581,28 @@ class TestMACAddressFieldArray(TestCase):
 
 class TestAggegate(TestCase):
     @skipIf(VERSION < (1, 9), 'Postgres aggregates not supported in Django < 1.9')
-    def test_aggregate(self):
-        from django.contrib.postgres.aggregates import ArrayAgg
-
-        network = IPv4Network('10.10.10.10/32')
+    def test_aggregate_inet(self):
+        from django.contrib.postgres.aggregates import ArrayAgg        
         inet = IPv4Interface('10.20.30.20/32')
-
+        network = IPv4Network('10.10.10.10/32')
+        
         parent = AggregateTestModel.objects.create()
-        network_qs = AggregateTestModel.objects.annotate(agg_network=ArrayAgg('children__network'))
         inet_qs = AggregateTestModel.objects.annotate(agg_inet=ArrayAgg('children__inet'))
-
-        self.assertEqual(network_qs[0].agg_network, [])
+        
         self.assertEqual(inet_qs[0].agg_inet, [])
 
         AggregateTestChildModel.objects.create(parent=parent, network=network, inet=inet)
-        self.assertEqual(network_qs[0].agg_network, [network])
         self.assertEqual(inet_qs[0].agg_inet, [inet])
+        
+    @skipIf(VERSION < (1, 9), 'Postgres aggregates not supported in Django < 1.9')
+    def test_aggregate_network(self):
+        from django.contrib.postgres.aggregates import ArrayAgg  
+        inet = IPv4Interface('10.20.30.20/32')
+        network = IPv4Network('10.10.10.10/32')
+        
+        parent = AggregateTestModel.objects.create()
+        network_qs = AggregateTestModel.objects.annotate(agg_network=ArrayAgg('children__network'))
+        
+        self.assertEqual(network_qs[0].agg_network, [])
+        AggregateTestChildModel.objects.create(parent=parent, network=network, inet=inet)
+        self.assertEqual(network_qs[0].agg_network, [network])

--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -19,7 +19,6 @@ from django.db import IntegrityError
 from django.db.models.sql import EmptyResultSet
 from django.core.exceptions import FieldError
 from django.test import TestCase
-from django.contrib.postgres.aggregates import ArrayAgg
 from unittest import skipIf
 
 from test.models import (
@@ -581,7 +580,10 @@ class TestMACAddressFieldArray(TestCase):
 
 
 class TestAggegate(TestCase):
+    @skipIf(VERSION < (1, 9), 'Postgres aggregates not supported in Django < 1.9')
     def test_aggregate(self):
+        from django.contrib.postgres.aggregates import ArrayAgg
+
         network = IPv4Network('10.10.10.10/32')
         inet = IPv4Interface('10.20.30.20/32')
 


### PR DESCRIPTION
If you try and use `ArrayAgg` with a netfield it fails because a list is passed to `from_db_value`. In the case that there are no results in the aggregation `[None]` is passed.

Without this patch it fails because it tries to pass a list to the `to_python` method which throws a confusing validation error. This iterates over the list and calls `to_python` individually.

I also added tests for this. Let me know if it's OK :+1: 