### PR TITLE
psycopg2.extensions.b was removed in 2.7

### DIFF
--- a/netfields/psycopg2_types.py
+++ b/netfields/psycopg2_types.py
@@ -10,7 +10,7 @@ class Macaddr(Inet):
         obj = psycopg2.extensions.adapt(self.addr)
         if hasattr(obj, 'prepare'):
             obj.prepare(self._conn)
-        return obj.getquoted() + psycopg2.extensions.b("::macaddr")
+        return obj.getquoted() + b"::macaddr"
  
 
 # Register array types for CIDR and MACADDR (Django already registers INET) 


### PR DESCRIPTION
The newest version of psycopg2 has removed the b() method. 

commit message from the psycopg2 repo:

commit 78649f8e905f04c3000abef23725d557a103abef
Author: Daniele Varrazzo <daniele.varrazzo@gmail.com>
Date:   Mon Aug 15 01:55:57 2016 +0100

Dropped use of b() "macro" and 2to3 fixer

Just use the b"" strings syntax supported from python 2.6.