### PR TITLE
use *args instead of context

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -37,7 +37,7 @@ class _NetAddressField(models.Field):
         kwargs['max_length'] = self.max_length
         super(_NetAddressField, self).__init__(*args, **kwargs)
 
-    def from_db_value(self, value, expression, connection, context=None):
+    def from_db_value(self, value, expression, connection, *args):
         if isinstance(value, list):
             # Aggregation detected, return a list of values. This is no longer
             # necessary in Django 2.1
@@ -161,7 +161,7 @@ class MACAddressField(models.Field):
     def db_type(self, connection):
         return 'macaddr'
 
-    def from_db_value(self, value, expression, connection, context=None):
+    def from_db_value(self, value, expression, connection, *args):
         return self.to_python(value)
 
     def to_python(self, value):


### PR DESCRIPTION
I'd love to get rid of some of my thousands of DeprecationWarnings. This should help...