### PR TITLE
The django.db.backends.postgresql_psycopg2.base is deprecated

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.backends.postgresql_psycopg2.base import DatabaseWrapper
+from django.db.backends.postgresql.base import DatabaseWrapper
 from django.utils.six import with_metaclass, text_type
 from ipaddress import ip_interface, ip_network
 from netaddr import EUI


### PR DESCRIPTION
The django.db.backends.postgresql_psycopg2.base is deprecated Django>=2.0 and removed in Django>=3.0b1

This causes an issue with Django>=3.0b1.