### PR TITLE
Change __prefixlen to be a Transform instead of a Lookup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,14 @@ matrix:
       env: TOX_ENV=py36-django22
     - python: 3.7
       env: TOX_ENV=py37-django22
+    - python: 3.8
+      env: TOX_ENV=py38-django22
     - python: 3.6
       env: TOX_ENV=py36-django30
     - python: 3.7
       env: TOX_ENV=py37-django30
+    - python: 3.8
+      env: TOX_ENV=py38-django30
 
 install:
   - pip install tox

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ added:
 These correspond with the operators and functions from
 http://www.postgresql.org/docs/9.4/interactive/functions-net.html
 
-``CidrAddressField`` includes two extra lookups:
+``CidrAddressField`` includes two extra lookups (these will be depreciated in the future by ``__prefixlen``):
 
 ``__max_prefixlen``
     Maximum value (inclusive) for ``CIDR`` prefix, does not distinguish between IPv4 and IPv6

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,9 @@ added:
 ``__host``
     matches the host part of an address regardless of prefix length
 
+``__prefixlen``
+    matches the prefix length part of an address
+
 These correspond with the operators and functions from
 http://www.postgresql.org/docs/9.4/interactive/functions-net.html
 

--- a/netfields/apps.py
+++ b/netfields/apps.py
@@ -68,4 +68,5 @@ class NetfieldsConfig(AppConfig):
     InetAddressField.register_lookup(NetContainsOrEquals)
     InetAddressField.register_lookup(NetOverlaps)
     InetAddressField.register_lookup(Family)
+    InetAddressField.register_lookup(Prefixlen)
     InetAddressField.register_lookup(HostMatches)

--- a/netfields/lookups.py
+++ b/netfields/lookups.py
@@ -1,3 +1,4 @@
+import warnings
 from django.core.exceptions import FieldError
 from django.db.models import Lookup, Transform, IntegerField
 from django.db.models.lookups import EndsWith, IEndsWith, StartsWith, IStartsWith, Regex, IRegex
@@ -152,6 +153,11 @@ class _PrefixlenMixin(object):
     format_string = None
 
     def as_sql(self, qn, connection):
+        warnings.warn(
+            'min_prefixlen and max_prefixlen will be depreciated in the future; '
+            'use __prefixlen__gte and __prefixlen__lte respectively',
+            DeprecationWarning
+        )
         assert self.format_string is not None, "Prefixlen lookups must specify a format_string"
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)

--- a/netfields/lookups.py
+++ b/netfields/lookups.py
@@ -155,7 +155,7 @@ class _PrefixlenMixin(object):
     def as_sql(self, qn, connection):
         warnings.warn(
             'min_prefixlen and max_prefixlen will be depreciated in the future; '
-            'use __prefixlen__gte and __prefixlen__lte respectively',
+            'use prefixlen__gte and prefixlen__lte respectively',
             DeprecationWarning
         )
         assert self.format_string is not None, "Prefixlen lookups must specify a format_string"

--- a/netfields/lookups.py
+++ b/netfields/lookups.py
@@ -178,6 +178,13 @@ class MinPrefixlen(_PrefixlenMixin, Lookup):
     format_string = '%s >= %s'
 
 
-class Prefixlen(_PrefixlenMixin, Lookup):
+class Prefixlen(Transform):
     lookup_name = 'prefixlen'
-    format_string = '%s = %s'
+
+    def as_sql(self, compiler, connection):
+        lhs, params = compiler.compile(self.lhs)
+        return "masklen(%s)" % lhs, params
+
+    @property
+    def output_field(self):
+        return IntegerField()

--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import warnings
 import django
 from django import VERSION
 from django.core.exceptions import ValidationError
@@ -367,16 +368,24 @@ class BaseCidrFieldTestCase(BaseInetTestCase):
         self.model.objects.filter(field=ip_network('1.2.3.0/24'))
 
     def test_max_prefixlen(self):
-        self.assertSqlEquals(
-            self.qs.filter(field__max_prefixlen='16'),
-            self.select + 'WHERE masklen("table"."field") <= %s'
-        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.assertSqlEquals(
+                self.qs.filter(field__max_prefixlen='16'),
+                self.select + 'WHERE masklen("table"."field") <= %s'
+            )
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
 
     def test_min_prefixlen(self):
-        self.assertSqlEquals(
-            self.qs.filter(field__min_prefixlen='16'),
-            self.select + 'WHERE masklen("table"."field") >= %s'
-        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.assertSqlEquals(
+                self.qs.filter(field__min_prefixlen='16'),
+                self.select + 'WHERE masklen("table"."field") >= %s'
+            )
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
 
 
 class TestInetField(BaseInetFieldTestCase, TestCase):

--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -193,6 +193,68 @@ class BaseInetTestCase(BaseSqlTestCase):
             self.select + 'WHERE HOST("table"."field") = HOST(%s)'
         )
 
+    def test_prefixlen_exact_lookup_sql(self):
+        self.assertSqlEquals(
+            self.qs.filter(field__prefixlen='16'),
+            self.select + 'WHERE MASKLEN("table"."field") = %s'
+        )
+
+    def test_prefixlen_in_lookup_sql(self):
+        self.assertSqlEquals(
+            self.qs.filter(field__prefixlen__in=['16', '24']),
+            self.select + 'WHERE MASKLEN("table"."field") IN (%s, %s)'
+        )
+
+    def test_prefixlen_in_single_lookup_sql(self):
+        self.assertSqlEquals(
+            self.qs.filter(field__prefixlen__in=['16']),
+            self.select + 'WHERE MASKLEN("table"."field") IN (%s)'
+        )
+
+    def test_prefixlen_in_empty_lookup_sql(self):
+        with self.assertRaises(EmptyResultSet):
+            self.qs.filter(field__prefixlen__in=[]).query.get_compiler(self.qs.db).as_sql()
+
+    def test_prefixlen_gt_lookup_sql(self):
+        self.assertSqlEquals(
+            self.qs.filter(field__prefixlen__gt="16"),
+            self.select + 'WHERE MASKLEN("table"."field") > %s'
+        )
+
+    def test_prefixlen_gte_lookup_sql(self):
+        self.assertSqlEquals(
+            self.qs.filter(field__prefixlen__gte="16"),
+            self.select + 'WHERE MASKLEN("table"."field") >= %s'
+        )
+
+    def test_prefixlen_lt_lookup_sql(self):
+        self.assertSqlEquals(
+            self.qs.filter(field__prefixlen__lt="16"),
+            self.select + 'WHERE MASKLEN("table"."field") < %s'
+        )
+
+    def test_prefixlen_lte_lookup_sql(self):
+        self.assertSqlEquals(
+            self.qs.filter(field__prefixlen__lte="16"),
+            self.select + 'WHERE MASKLEN("table"."field") <= %s'
+        )
+
+    def test_query_filter_f_expression(self):
+        self.model.objects.filter(field=F('field'))
+
+    @skipIf(VERSION < (1, 11), 'Subquery added in Django 1.11. https://docs.djangoproject.com/en/1.11/ref/models/expressions/#subquery-expressions')
+    def test_query_filter_subquery(self):
+        from django.db.models import OuterRef, Subquery
+        self.model.objects.annotate(
+            samefield=Subquery(
+                self.model.objects
+                .filter(
+                    field=OuterRef('field')
+                )
+                .values('field')[:1]
+            )
+        )
+
 
 class BaseInetFieldTestCase(BaseInetTestCase):
     value1 = '10.0.0.1'
@@ -240,22 +302,6 @@ class BaseInetFieldTestCase(BaseInetTestCase):
 
     def test_query_filter_ipaddress(self):
         self.model.objects.filter(field=ip_interface('1.2.3.4'))
-
-    def test_query_filter_f_expression(self):
-        self.model.objects.filter(field=F('field'))
-
-    @skipIf(VERSION < (1, 11), 'Subquery added in Django 1.11. https://docs.djangoproject.com/en/1.11/ref/models/expressions/#subquery-expressions')
-    def test_query_filter_subquery(self):
-        from django.db.models import OuterRef, Subquery
-        self.model.objects.annotate(
-            samefield=Subquery(
-                self.model.objects
-                .filter(
-                    field=OuterRef('field')
-                )
-                .values('field')[:1]
-            )
-        )
 
     def test_query_filter_contains_ipnetwork(self):
         self.model.objects.filter(field__net_contains=ip_network(u'2001::0/16'))
@@ -320,22 +366,6 @@ class BaseCidrFieldTestCase(BaseInetTestCase):
     def test_query_filter_ipnetwork(self):
         self.model.objects.filter(field=ip_network('1.2.3.0/24'))
 
-    def test_query_filter_f_expression(self):
-        self.model.objects.filter(field=F('field'))
-
-    @skipIf(VERSION < (1, 11), 'Subquery added in Django 1.11. https://docs.djangoproject.com/en/1.11/ref/models/expressions/#subquery-expressions')
-    def test_query_filter_subquery(self):
-        from django.db.models import OuterRef, Subquery
-        self.model.objects.annotate(
-            samefield=Subquery(
-                self.model.objects
-                .filter(
-                    field=OuterRef('field')
-                )
-                .values('field')[:1]
-            )
-        )
-
     def test_max_prefixlen(self):
         self.assertSqlEquals(
             self.qs.filter(field__max_prefixlen='16'),
@@ -346,12 +376,6 @@ class BaseCidrFieldTestCase(BaseInetTestCase):
         self.assertSqlEquals(
             self.qs.filter(field__min_prefixlen='16'),
             self.select + 'WHERE masklen("table"."field") >= %s'
-        )
-
-    def test_prefixlen(self):
-        self.assertSqlEquals(
-            self.qs.filter(field__prefixlen='16'),
-            self.select + 'WHERE masklen("table"."field") = %s'
         )
 
 
@@ -450,6 +474,7 @@ class TestInetFieldNoPrefix(BaseInetFieldTestCase, TestCase):
         query = self.model.objects.filter(field__net_contained='10.1.2.0/24')
         self.assertEqual(query.count(), 1)
         self.assertEqual(query[0].field, ip_address('10.1.2.1'))
+
 
 class TestCidrField(BaseCidrFieldTestCase, TestCase):
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,10 @@ envlist=
     py35-django22,
     py36-django22,
     py37-django22,
+    py38-django22,
     py36-django30,
     py37-django30,
-
+    py38-django30,
 
 
 [testenv]
@@ -330,6 +331,15 @@ deps=
     djangorestframework
     unittest2
 
+[testenv:py38-django22]
+basepython=python3.8
+deps=
+    django>=2.2,<3.0
+    netaddr
+    psycopg2
+    djangorestframework
+    unittest2
+
 [testenv:py36-django30]
 basepython=python3.6
 deps=
@@ -341,6 +351,15 @@ deps=
 
 [testenv:py37-django30]
 basepython=python3.7
+deps=
+    django>=3.0,<3.1
+    netaddr
+    psycopg2
+    djangorestframework
+    unittest2
+
+[testenv:py38-django30]
+basepython=python3.8
 deps=
     django>=3.0,<3.1
     netaddr


### PR DESCRIPTION
- Fixes #62.  Note that this changes the original behavior of __prefixlen to be a Transform instead of a Lookup.  Depreciation warnings were also added to __min_prefixlen and __max_prefixlen.
- Adds __prefixlen lookup to InetAddressField.
- Adds python3.8 builds to django 2.2+.
- Moves redundant test cases from BaseInetFieldTestCase/BaseCidrFieldTestCase to BaseInetTestCase.