### PR TITLE
handle more invalid macs in DRF MACAddressField

### DIFF
--- a/netfields/rest_framework.py
+++ b/netfields/rest_framework.py
@@ -72,5 +72,5 @@ class MACAddressField(serializers.Field):
             return data
         try:
             return EUI(data, dialect=mac_unix_common)
-        except AddrFormatError:
+        except (AddrFormatError, TypeError):
             self.fail('invalid')

--- a/test/tests/test_rest_framework_fields.py
+++ b/test/tests/test_rest_framework_fields.py
@@ -49,11 +49,12 @@ class FieldsTestCase(unittest.TestCase):
         class TestSerializer(serializers.Serializer):
             mac = fields.MACAddressField()
 
-        address = 'de:'
-        serializer = TestSerializer(data={'mac': address})
-        with self.assertRaises(serializers.ValidationError) as e:
-            serializer.is_valid(raise_exception=True)
-        self.assertEqual(e.exception.detail['mac'], ["Invalid MAC address."])
+        for invalid_address in ("de:", {"not": "a mac"}):
+            with self.subTest(invalid_address=invalid_address):
+                serializer = TestSerializer(data={'mac': invalid_address})
+                with self.assertRaises(serializers.ValidationError) as e:
+                    serializer.is_valid(raise_exception=True)
+                self.assertEqual(e.exception.detail['mac'], ["Invalid MAC address."])
 
     def test_inet_validation_additional_validators(self):
         def validate(value):


### PR DESCRIPTION
Hello,

I've noticed that trying to validate garbage (like a `dict`) as a MAC address isn't handled in the DRF `MACAddressField`, so the `TypeError` bubble up and ultimately results in a 500 error in my projects.

I think simply catching `TypeError` does the job, don't hesitate if you think I'm mistaken.