### PR TITLE
Add NetModelSerializer to rest_framework

### DIFF
--- a/netfields/rest_framework.py
+++ b/netfields/rest_framework.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 
 from netfields.compat import text_type
 from netfields.mac import mac_unix_common
+from netfields import fields
 
 
 class InetAddressField(serializers.Field):
@@ -74,3 +75,12 @@ class MACAddressField(serializers.Field):
             return EUI(data, dialect=mac_unix_common)
         except AddrFormatError:
             self.fail('invalid')
+
+
+class NetModelSerializer(serializers.ModelSerializer):
+    pass
+
+
+NetModelSerializer.serializer_field_mapping[fields.InetAddressField] = InetAddressField
+NetModelSerializer.serializer_field_mapping[fields.CidrAddressField] = CidrAddressField
+NetModelSerializer.serializer_field_mapping[fields.MACAddressField] = MACAddressField


### PR DESCRIPTION
As of now if someone uses a model with any netfields in conjunction with rest-framework `ModelSerializer` its required to override `ModelSerializer.serializer_field_mapping` in order to make it use the right serializer fields.

If this is not done `serializers.ModelSerializer` uses `serializers.ModelField` for any of netfields. This than causes an `AttributeError` due to `ModelField.to_representation` implementation.

This PR addresses this by provindi a subclass of `ModelSerializer` with an updated field mapping.