### PR TITLE
Change InetAddressField form value based on prefix parameter.

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -6,7 +6,7 @@ from netaddr import EUI
 from netaddr.core import AddrFormatError
 
 from netfields.compat import DatabaseWrapper, with_metaclass, text_type
-from netfields.forms import InetAddressFormField, CidrAddressFormField, MACAddressFormField
+from netfields.forms import InetAddressFormField, NoPrefixInetAddressFormField, CidrAddressFormField, MACAddressFormField
 from netfields.mac import mac_unix_common
 from netfields.psycopg2_types import Inet, Macaddr
 
@@ -146,7 +146,9 @@ class InetAddressField(_NetAddressField):
         return value
 
     def form_class(self):
-        return InetAddressFormField
+        if self.store_prefix_length:
+            return InetAddressFormField
+        return NoPrefixInetAddressFormField
 
 
 class CidrAddressField(_NetAddressField):

--- a/netfields/forms.py
+++ b/netfields/forms.py
@@ -1,4 +1,4 @@
-from ipaddress import ip_interface, ip_network, _IPAddressBase, _BaseNetwork
+from ipaddress import ip_address, ip_interface, ip_network, _IPAddressBase, _BaseNetwork
 from netaddr import EUI, AddrFormatError
 
 from django import forms
@@ -29,7 +29,32 @@ class InetAddressFormField(forms.Field):
 
         try:
             return ip_interface(value)
-        except ValueError as e:
+        except ValueError:
+            raise ValidationError(self.error_messages['invalid'])
+
+
+class NoPrefixInetAddressFormField(forms.Field):
+    widget = forms.TextInput
+    default_error_messages = {
+        'invalid': u'Enter a valid IP address.',
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(NoPrefixInetAddressFormField, self).__init__(*args, **kwargs)
+
+    def to_python(self, value):
+        if not value:
+            return None
+
+        if isinstance(value, _IPAddressBase):
+            return value
+
+        if isinstance(value, text_type):
+            value = value.strip()
+
+        try:
+            return ip_address(value)
+        except ValueError:
             raise ValidationError(self.error_messages['invalid'])
 
 

--- a/test/tests/test_form_fields.py
+++ b/test/tests/test_form_fields.py
@@ -82,50 +82,30 @@ class TestNoPrefixInetAddressFormField(TestCase):
     def test_form_ipv4_valid(self):
         form = self.form_class({'field': '10.0.0.1'})
         self.assertTrue(form.is_valid())
-        # Form always passes ip_interface. Model field will return the requested type
-        self.assertEqual(form.cleaned_data['field'], ip_interface('10.0.0.1'))
+        self.assertEqual(form.cleaned_data['field'], ip_address('10.0.0.1'))
 
     def test_form_ipv4_invalid(self):
         form = self.form_class({'field': '10.0.0.1.2'})
         self.assertFalse(form.is_valid())
 
-    def test_form_ipv4_strip(self):
-        form = self.form_class({'field': ' 10.0.0.1 '})
-        self.assertTrue(form.is_valid())
-        # Form always passes ip_interface. Model field will return the requested type
-        self.assertEqual(form.cleaned_data['field'], ip_interface('10.0.0.1'))
-
-    def test_form_ipv4_change(self):
+    def test_form_ipv4_prefix_invalid(self):
         instance = NoPrefixInetTestModel.objects.create(field='10.1.2.3/24')
         form = self.form_class({'field': '10.1.2.4/24'}, instance=instance)
-        self.assertTrue(form.is_valid())
-        form.save()
-        instance = NoPrefixInetTestModel.objects.get(pk=instance.pk)
-        self.assertEqual(instance.field, ip_address('10.1.2.4'))
+        self.assertFalse(form.is_valid())
 
     def test_form_ipv6_valid(self):
         form = self.form_class({'field': '2001:0:1::2'})
         self.assertTrue(form.is_valid())
-        # Form always passes ip_interface. Model field will return the requested type
-        self.assertEqual(form.cleaned_data['field'], ip_interface('2001:0:1::2'))
+        self.assertEqual(form.cleaned_data['field'], ip_address('2001:0:1::2'))
 
     def test_form_ipv6_invalid(self):
         form = self.form_class({'field': '2001:0::1::2'})
         self.assertFalse(form.is_valid())
 
-    def test_form_ipv6_strip(self):
-        form = self.form_class({'field': ' 2001:0:1::2 '})
-        self.assertTrue(form.is_valid())
-        # Form always passes ip_interface. Model field will return the requested type
-        self.assertEqual(form.cleaned_data['field'], ip_interface('2001:0:1::2'))
-
-    def test_form_ipv6_change(self):
+    def test_form_ipv6_prefix_invalid(self):
         instance = NoPrefixInetTestModel.objects.create(field='2001:0:1::2/64')
         form = self.form_class({'field': '2001:0:1::3/64'}, instance=instance)
-        self.assertTrue(form.is_valid())
-        form.save()
-        instance = NoPrefixInetTestModel.objects.get(pk=instance.pk)
-        self.assertEqual(instance.field, ip_address('2001:0:1::3'))
+        self.assertFalse(form.is_valid())
 
 
 class UniqueInetAddressTestModelForm(ModelForm):


### PR DESCRIPTION
This change adds type `NoPrefixInetAddressFormField` that is used when `store_prefix_length=False`, and returns type `ip_address` instead of `ip_interface`. With this change, the form for `InetAddressField` will no longer automatically append network prefixes to the IP when `store_prefix_length=False`.