### PR TITLE
Avoid a deprecation warning

### DIFF
--- a/netfields/__init__.py
+++ b/netfields/__init__.py
@@ -1,5 +1,9 @@
+from django import VERSION
+
 from netfields.managers import NetManager
 from netfields.fields import (InetAddressField, CidrAddressField,
                               MACAddressField)
 
-default_app_config = 'netfields.apps.NetfieldsConfig'
+# only keep it for django 3.1 and below
+if VERSION[0] < 3 or VERSION[0] == 3 and VERSION[1]  < 2:
+    default_app_config = 'netfields.apps.NetfieldsConfig'


### PR DESCRIPTION
``
RemovedInDjango41Warning: 'netfields' defines default_app_config = 'netfields.apps.NetfieldsConfig'. Django now detects this configuration automatically. You can remove default_app_config.
``

See https://code.djangoproject.com/ticket/31180

Since django 3.2 the warning is shown: https://github.com/django/django/commit/3f2821af6bc48fa8e7970c1ce27bc54c3172545e