### PR TITLE
Fix potential MacAddressField crash in DRF

### DIFF
--- a/netfields/forms.py
+++ b/netfields/forms.py
@@ -108,7 +108,7 @@ class MACAddressFormField(forms.Field):
 
         try:
             return EUI(value, dialect=mac_unix_common)
-        except (AddrFormatError, TypeError):
+        except (AddrFormatError, IndexError, TypeError):
             raise ValidationError(self.error_messages['invalid'])
 
     def widget_attrs(self, widget):


### PR DESCRIPTION
Using the MACAddressField on a model, then attempting to submit an "extra large" mac address such as `be:ef:be:ef:be:ef:be:ef` results in an IndexError, which gets bubbled out of DRF and results in a 500 ServerError.  This should raise a ValidationError instead.