### PR TITLE
Fix uncaught EUI() exceptions

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -188,7 +188,7 @@ class MACAddressField(models.Field):
 
         try:
             return EUI(value, dialect=mac_unix_common)
-        except AddrFormatError as e:
+        except (AddrFormatError, IndexError, TypeError) as e:
             raise ValidationError(e)
 
     def get_prep_value(self, value):
@@ -234,7 +234,7 @@ class MACAddress8Field(models.Field):
 
         try:
             return EUI(value, dialect=mac_eui64)
-        except AddrFormatError as e:
+        except (AddrFormatError, IndexError, TypeError) as e:
             raise ValidationError(e)
 
     def get_prep_value(self, value):

--- a/netfields/rest_framework.py
+++ b/netfields/rest_framework.py
@@ -74,7 +74,7 @@ class MACAddressField(serializers.Field):
             return data
         try:
             return EUI(data, dialect=mac_unix_common)
-        except (AddrFormatError, TypeError):
+        except (AddrFormatError, IndexError, TypeError):
             self.fail('invalid')
 
 
@@ -93,7 +93,7 @@ class MACAddress8Field(serializers.Field):
             return data
         try:
             return EUI(data, dialect=mac_eui64)
-        except (AddrFormatError, TypeError):
+        except (AddrFormatError, IndexError, TypeError):
             self.fail('invalid')
 
 


### PR DESCRIPTION
In some cases, `netaddr.EUI()` can throw `IndexError` and `TypeError` in addition to `netaddr.AddrFormatError`. This was handled correctly in `MACAddressFormField`, but was missing in some other places.