### PR TITLE
Add support for psycopg v3

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -20,6 +20,7 @@ jobs:
             python-version {3.8}, tox-env {py38-django111,py38-django22,py38-django30,py38-django31,py38-django32,py38-django40}
             python-version {3.9}, tox-env {py38-django111,py38-django22,py38-django30,py38-django31,py38-django32,py38-django40}
             python-version {3.10}, tox-env {py310-django32,py310-django40}
+            python-version {3.11}, tox-env {py311-django42,py311-django42-psycopg3}
     outputs:
       matrix: ${{ steps.create_matrix.outputs.matrix }}
   build:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -14,11 +14,9 @@ jobs:
         with:
           matrix: |
             python-version {2.7}, tox-env {py27-django111}
-            python-version {3.5}, tox-env {py35-django111,py35-django22}
-            python-version {3.6}, tox-env {py36-django111,py36-django22,py36-django30,py36-django31,py36-django32}
             python-version {3.7}, tox-env {py37-django111,py37-django22,py37-django30,py37-django31,py37-django32}
             python-version {3.8}, tox-env {py38-django111,py38-django22,py38-django30,py38-django31,py38-django32,py38-django40}
-            python-version {3.9}, tox-env {py38-django111,py38-django22,py38-django30,py38-django31,py38-django32,py38-django40}
+            python-version {3.9}, tox-env {py39-django111,py39-django22,py39-django30,py39-django31,py39-django32,py39-django40}
             python-version {3.10}, tox-env {py310-django32,py310-django40}
             python-version {3.11}, tox-env {py311-django42,py311-django42-psycopg3}
     outputs:

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ fields are represented as EUI types from the netaddr_ module.
 Dependencies
 ------------
 
-This module requires ``Django >= 1.11``, ``psycopg2``, and ``netaddr``.
+This module requires ``Django >= 1.11``, ``psycopg2`` or ``psycopg``, and ``netaddr``.
 
 Installation
 ------------

--- a/netfields/compat.py
+++ b/netfields/compat.py
@@ -5,6 +5,11 @@ if VERSION[0] < 2:
 else:
     from django.db.backends.postgresql.base import DatabaseWrapper
 
+try:
+    from django.db.backends.postgresql.base import is_psycopg3
+except ImportError:
+    is_psycopg3 = False
+
 if VERSION[0] <= 2:
     from django.utils.six import with_metaclass, text_type
 else:

--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -14,7 +14,10 @@ from netfields.forms import (
     MACAddress8FormField
 )
 from netfields.mac import mac_unix_common, mac_eui64
-from netfields.psycopg2_types import Inet, Macaddr, Macaddr8
+try:
+    from netfields.psycopg2_types import Inet, Macaddr, Macaddr8
+except ImportError:
+    from netfields.psycopg3_types import Inet, Macaddr, Macaddr8
 
 
 NET_OPERATORS = DatabaseWrapper.operators.copy()

--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -5,7 +5,7 @@ from ipaddress import ip_interface, ip_network
 from netaddr import EUI
 from netaddr.core import AddrFormatError
 
-from netfields.compat import DatabaseWrapper, with_metaclass, text_type
+from netfields.compat import DatabaseWrapper, is_psycopg3, with_metaclass, text_type
 from netfields.forms import (
     InetAddressFormField,
     NoPrefixInetAddressFormField,
@@ -14,10 +14,11 @@ from netfields.forms import (
     MACAddress8FormField
 )
 from netfields.mac import mac_unix_common, mac_eui64
-try:
-    from netfields.psycopg2_types import Inet, Macaddr, Macaddr8
-except ImportError:
+
+if is_psycopg3:
     from netfields.psycopg3_types import Inet, Macaddr, Macaddr8
+else:
+    from netfields.psycopg2_types import Inet, Macaddr, Macaddr8
 
 
 NET_OPERATORS = DatabaseWrapper.operators.copy()

--- a/netfields/psycopg3_types.py
+++ b/netfields/psycopg3_types.py
@@ -1,0 +1,49 @@
+from psycopg.adapt import Dumper, Loader
+from psycopg.postgres import adapters
+
+
+class Inet(str):
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, self)
+
+
+class Macaddr(Inet):
+    pass
+
+
+class Macaddr8(Inet):
+    pass
+
+
+class _MacaddrDumper(Dumper):
+    oid = adapters.types['macaddr'].oid
+
+    def dump(self, obj):
+        return str(obj).encode()
+
+
+class _MacaddrLoader(Loader):
+    def load(self, data):
+        if isinstance(data, memoryview):
+            data = bytes(data)
+        return Macaddr(data.decode())
+
+
+class _Macaddr8Dumper(Dumper):
+    oid = adapters.types['macaddr8'].oid
+
+    def dump(self, obj):
+        return str(obj).encode()
+
+
+class _Macaddr8Loader(Loader):
+    def load(self, data):
+        if isinstance(data, memoryview):
+            data = bytes(data)
+        return Macaddr8(data.decode())
+
+
+adapters.register_loader('macaddr', _MacaddrLoader)
+adapters.register_loader('macaddr8', _Macaddr8Loader)
+adapters.register_dumper(Macaddr, _MacaddrDumper)
+adapters.register_dumper(Macaddr8, _Macaddr8Dumper)

--- a/testsettings.py
+++ b/testsettings.py
@@ -2,7 +2,7 @@ import os
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'netfields',
     }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ envlist=
     py38-django40,
     py38-django40,
     py310-django40,
+    py311-django42,
+    py311-django42-psycopg3,
 
 [testenv]
 commands=
@@ -250,4 +252,20 @@ deps=
     django>=4.0,<4.1
     netaddr
     psycopg2-binary
+    djangorestframework
+
+[testenv:py311-django42]
+basepython=python3.11
+deps=
+    django>=4.2,<4.3
+    netaddr
+    psycopg2-binary
+    djangorestframework
+
+[testenv:py311-django42-psycopg3]
+basepython=python3.11
+deps=
+    django>=4.2,<4.3
+    netaddr
+    psycopg[binary]
     djangorestframework


### PR DESCRIPTION
This pull request adds support for [psycopg v3](https://www.psycopg.org/psycopg3/docs/index.html) given that the recent [Django 4.2 release](https://docs.djangoproject.com/en/4.2/releases/4.2/#psycopg-3-support) now supports it. Resolves https://github.com/jimfunk/django-postgresql-netfields/issues/121.

Summary of changes:

1. In the test settings, update `django.db.backends.postgresql_psycopg2` to `django.db.backends.postgresql` as this has been supported since [Django 1.9](https://docs.djangoproject.com/en/dev/releases/1.9/#database-backends) and it makes it more explicit that we're no longer coupled only to psycopg2.
2. Add a new tox configuration to test the latest Python with Django 4.2 and psycopg v3. Also add another new tox configuration to test with psycopg2 to ensure that no regressions are introduced.
3. Re-implement the interface exposed by `psycopg2_types` via `psycopg`. The code is pretty straight forward, essentially just wrapping `str` in custom types so that we can connect the dumpers and loaders.
4. Drop Python 3.5 and Python 3.6 from the Github Action matrix as they lead to builds to fail due to being end of life ([log for 3.5](https://github.com/c-w/django-postgresql-netfields/actions/runs/4632708593/jobs/8197104183), [log for 3.6](https://github.com/c-w/django-postgresql-netfields/actions/runs/4632708593/jobs/8197104443)).
5. Fix a typo in the Github Actions matrix for Python 3.9 which erroneously ran the tests against the Python 3.8 tox environment and caused builds to fail as Python 3.8 isn't included by default on the Github Actions runner anymore ([see log for 3.9](https://github.com/c-w/django-postgresql-netfields/actions/runs/4632708593/jobs/8197106453)).