### PR TITLE
Fix Django versions used in tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -263,7 +263,7 @@ deps=
 [testenv:py38-django41]
 basepython=python3.8
 deps=
-    django>=4.0,<4.1
+    django>=4.1,<4.2
     netaddr
     psycopg2-binary
     djangorestframework
@@ -271,7 +271,7 @@ deps=
 [testenv:py39-django41]
 basepython=python3.9
 deps=
-    django>=4.0,<4.1
+    django>=4.1,<4.2
     netaddr
     psycopg2-binary
     djangorestframework
@@ -279,7 +279,7 @@ deps=
 [testenv:py310-django41]
 basepython=python3.10
 deps=
-    django>=4.0,<4.1
+    django>=4.1,<4.2
     netaddr
     psycopg2-binary
     djangorestframework
@@ -287,7 +287,7 @@ deps=
 [testenv:py311-django41]
 basepython=python3.11
 deps=
-    django>=4.0,<4.1
+    django>=4.1,<4.2
     netaddr
     psycopg2-binary
     djangorestframework
@@ -295,7 +295,7 @@ deps=
 [testenv:py38-django42]
 basepython=python3.8
 deps=
-    django>=4.0,<4.1
+    django>=4.2,<4.3
     netaddr
     psycopg2-binary
     djangorestframework
@@ -303,7 +303,7 @@ deps=
 [testenv:py39-django42]
 basepython=python3.9
 deps=
-    django>=4.0,<4.1
+    django>=4.2,<4.3
     netaddr
     psycopg2-binary
     djangorestframework
@@ -311,7 +311,7 @@ deps=
 [testenv:py310-django42]
 basepython=python3.10
 deps=
-    django>=4.0,<4.1
+    django>=4.2,<4.3
     netaddr
     psycopg2-binary
     djangorestframework
@@ -319,7 +319,7 @@ deps=
 [testenv:py311-django42]
 basepython=python3.11
 deps=
-    django>=4.0,<4.1
+    django>=4.2,<4.3
     netaddr
     psycopg2-binary
     djangorestframework


### PR DESCRIPTION
In 6ef177c several new tox environments were added to test new versions of Python and Django. Unfortunately the Django versions in the requirements and environment names were out of sync.

I discovered this as I was running some tests on the `py311-django42` environment but was wondering why the actual code of Django was at versino 4.0.x