### PR TITLE
Add get_placeholder to handle automatic check constraint evaluation

### DIFF
--- a/netfields/fields.py
+++ b/netfields/fields.py
@@ -120,6 +120,9 @@ class _NetAddressField(models.Field):
         return super(_NetAddressField, self).get_db_prep_lookup(
             lookup_type, value, connection=connection, prepared=prepared)
 
+    def get_placeholder(self, value, compiler, connection):
+        return "%s::{}".format(self.db_type(connection))
+
     def formfield(self, **kwargs):
         defaults = {'form_class': self.form_class()}
         defaults.update(kwargs)

--- a/test/models.py
+++ b/test/models.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import CASCADE, ForeignKey, Model
 
@@ -117,3 +118,20 @@ class AggregateTestChildModel(Model):
     )
     network = CidrAddressField()
     inet = InetAddressField()
+
+
+if VERSION >= (4, 1):
+    from django.db.models import F, Q, CheckConstraint
+
+
+    class ConstraintModel(Model):
+        network = CidrAddressField()
+        inet = InetAddressField()
+
+        class Meta:
+            constraints = (
+                CheckConstraint(
+                    check=Q(network__net_contains=F('inet')),
+                    name='inet_contained',
+                ),
+            )

--- a/test/tests/test_sql_fields.py
+++ b/test/tests/test_sql_fields.py
@@ -772,3 +772,16 @@ class TestAggregate(TestCase):
         self.assertEqual(network_qs[0].agg_network, [None])
         AggregateTestChildModel.objects.create(parent=parent, network=network, inet=inet)
         self.assertEqual(network_qs[0].agg_network, [network])
+
+
+class TestConstraints(TestCase):
+
+    @skipIf(VERSION < (4, 1), 'Check constraint validation is supported from django 4.1 onwards')
+    def test_check_constraint(self):
+        from test.models import ConstraintModel
+
+        inet = IPv4Interface('10.10.10.20/32')
+        network = IPv4Network('10.10.10.0/24')
+        model = ConstraintModel(inet=inet, network=network)
+        model.full_clean()
+        model.save()


### PR DESCRIPTION
As from django 4.1 `CheckConstraint` are evaluated during the `Model.full_clean` process using model data.

As of now this does not work with netfields since the checker does not produce the right query (see https://github.com/sevdog/netfields-check-error for reference).
With a check constraint like the following: 

```python
CheckConstraint(check=Q(network__net_contains=F('inet')),name='inet_contained')
```

the ORM produces the following query: 

```sql
SELECT 1 AS "_check" WHERE COALESCE(('192.168.0.0/24' >> ('192.168.0.1')), true)
```

which raises an error on Postgresql since
> operator is not unique: `unknown >> unknown` [...] 
> HINT: Could not choose a best candidate operator. You might need to add explicit type casts

Thus if this is called inside a transaction then any following query will fail since the transaction is not on a clean state and raising

> current transaction is aborted, commands ignored until end of transaction block

Looking at similar issue on django (see https://code.djangoproject.com/ticket/34059) the solution seems to be adding a new method `Field.get_placeholder` which is used by ORM to insert values in this process.